### PR TITLE
Allow compiling with system mysql (libmysqlclient-dev)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,11 @@ ELSE()
   MESSAGE(WARNING "${MYSQL_DIR_NAME_DOCSTRING} was not specified. If something goes wrong re-reun with option -DMYSQL_DIR")  
 ENDIF()
 
-INCLUDE_DIRECTORIES("${MYSQL_DIR}/include")
+IF(EXISTS "${MYSQL_DIR}/include")
+  INCLUDE_DIRECTORIES("${MYSQL_DIR}/include")
+ELSE()
+  INCLUDE_DIRECTORIES("${MYSQL_DIR}")
+ENDIF()
 
 ADD_DEFINITIONS("-DMYSQL_DYNAMIC_PLUGIN")
 ADD_DEFINITIONS("-rdynamic")


### PR DESCRIPTION
The system mysql is in /usr/include/mysql

```
$ dpkg -S /usr/include/mysql
libmysqlclient-dev: /usr/include/mysql
$ apt-cache policy libmysqlclient-dev
libmysqlclient-dev:
  Installed: 5.6.23-1ubuntu14.04
  Candidate: 5.6.23-1ubuntu14.04
  Version table:
 *** 5.6.23-1ubuntu14.04 0
        500 http://repo.mysql.com/apt/ubuntu/ trusty/mysql-5.6 amd64 Packages
        100 /var/lib/dpkg/status
     5.5.41-0ubuntu0.14.10.1 0
        500 http://nl.archive.ubuntu.com/ubuntu/ utopic-updates/main amd64 Packages
        500 http://security.ubuntu.com/ubuntu/ utopic-security/main amd64 Packages
     5.5.40-0ubuntu1 0
        500 http://nl.archive.ubuntu.com/ubuntu/ utopic/main amd64 Packages
```
